### PR TITLE
[BUGFIX] Allow pngs rendedering with a transparent background

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -14,15 +14,9 @@ module.exports = (image,
     crop = false,
     cropMaxSize = 2000,
     gravity = sharp.gravity.center,
-    format = sharp.format.jpeg.id,
-    progressive = true,
-    quality = 80
   } = {}) =>
   sharp(image)
     .resize(...cropDimensions(width, height, cropMaxSize), {
       fit: crop ? 'cover' : 'outside',
       gravity
-    })[format]({
-      quality,
-      progressive
-    })
+    });


### PR DESCRIPTION
This PR is related to https://github.com/magento/pwa-studio/issues/1547.

I've tested both .png and .jpeg and it works as expected .png images have a transparent background when the original file has a transparent background.