### PR TITLE
fix: pass 'rejectUnauthorized: true' to request-promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ module.exports = function(options) {
 
       debug('Requesting:', imageUrl)
       let response = await request({
+        rejectUnauthorized: !!process.env.NODE_TLS_REJECT_UNAUTHORIZED,
         encoding: null,
         uri: imageUrl,
         resolveWithFullResponse: true,


### PR DESCRIPTION
Fixing the certificate untrust error for non-production stores.