### PR TITLE
BREAKING: Use path as URL instead of /resize/:width/:height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ build/Release
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
 .idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ app.listen(3000)
 Render `http://mybasehost.com/image.jpg` with 400x400 pixels:
 
 ```
-GET /my-scale/resize/400?url=%2Fimage.jpg HTTP/1.1
+GET /my-scale/image.jpg?width=400 HTTP/1.1
 Host: localhost:3000
 
 --> invokes in background:
@@ -45,7 +45,7 @@ Host: localhost:3000
 Same as above, but with 80% quality, `webp` image type and with progressive enabled:
 
 ```
-GET /my-scale/resize/400?format=webp&quality=80&progressive=true&url=%2Fimage.jpg HTTP/1.1
+GET /my-scale/image.jpg?format=webp&quality=80&progressive=true HTTP/1.1
 Host: localhost:3000
 ```
 
@@ -128,11 +128,6 @@ Possible attributes of the optional `gravity` are
 `north`, `northeast`, `east`, `southeast`, `south`, `southwest`, `west`, `northwest`, `center` and `centre`.
 
 Default is `center`;
-
-
-### `url`
-
-URL/path to original image.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,19 @@ const getImageUrl = function(baseHost, inputUrl) {
   return url.format(imageUrl)
 }
 
+const isUrlPathname = function(value) {
+  if (!value) {
+    return false
+  }
+  const u = url.parse(value)
+  if (u.protocol || u.host || !u.path) {
+    return false
+  }
+  return true
+}
+
 module.exports = function(options) {
+  debug('called with options: %O', options)
   const router = express.Router()
   router.use(expressValidator({
     customValidators: {
@@ -29,28 +41,13 @@ module.exports = function(options) {
       },
       isQuality: function(value) {
         return value >= 0 && value <= 100
-      },
-      isUrlPathQuery: function(value) {
-        if (!value) {
-          return false
-        }
-        const u = url.parse(value)
-        if (u.protocol || u.host || !u.path) {
-          return false
-        }
-        return true
-      },
+      }
     },
   }))
 
   const _cors = cors(options.cors || {})
-  router.get('/resize', _cors, async (req, res, next) => {
-    let format = req.query.format
-    if (req.headers.accept && req.headers.accept.indexOf('image/webp') !== -1) {
-      format = format || 'webp'
-    }
-    const quality = parseInt(req.query.quality || 75, 10)
 
+  const handler = async (req, res, next) => {
     req.checkQuery('height').optional().isInt()
     req.checkQuery('width').optional().isInt()
     req.checkQuery('format').optional().isSharpFormat()
@@ -58,15 +55,28 @@ module.exports = function(options) {
     req.checkQuery('progressive').optional().isBoolean()
     req.checkQuery('crop').optional().isBoolean()
     req.checkQuery('gravity').optional().isGravity()
-    req.checkQuery('url').isUrlPathQuery()
 
-    const errors = req.validationErrors()
-    if (errors) {
+    const errors = req.validationErrors() || []
+
+    if (!isUrlPathname(req.path)) {
+      errors.push({
+        message: `pathname ${req.path} is not a valid relative URL path`
+      })
+    }
+
+    if (errors.length > 0) {
       return res.status(400).json(errors)
     }
+
     debug('query %o is valid', req.query)
 
-    const imageUrl = getImageUrl(options.baseHost, req.query.url)
+    let format = req.query.format
+    if (req.headers.accept && req.headers.accept.indexOf('image/webp') !== -1) {
+      format = format || 'webp'
+    }
+    const quality = parseInt(req.query.quality || 75, 10)
+
+    const imageUrl = getImageUrl(options.baseHost, req.path)
 
     const width = parseInt(req.query.width, 10) || null
     const height = parseInt(req.query.height, 10) || null
@@ -117,7 +127,9 @@ module.exports = function(options) {
       if (e.statusCode === 404) return next()
       next(e)
     }
-  })
+  }
+
+  router.get('*', _cors, handler)
 
   return router
 }

--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ module.exports = function(options) {
     if (errors) {
       return res.status(400).json(errors)
     }
+    debug('query %o is valid', req.query)
 
     const imageUrl = getImageUrl(options.baseHost, req.query.url)
 
@@ -71,6 +72,8 @@ module.exports = function(options) {
     const height = parseInt(req.query.height, 10) || null
     const crop = req.query.crop === 'true'
     const gravity = req.query.gravity
+
+    debug('%o parsed from %s', { width, height, crop, gravity }, imageUrl)
 
     try {
       const etagBuffer = Buffer.from([imageUrl, width, height, format, quality])
@@ -110,6 +113,7 @@ module.exports = function(options) {
       imageStream.on('error', e => res.status(500).send(e))
       imageStream.pipe(res)
     } catch (e) {
+      debug('encountered error with %s: %s', imageUrl, e)
       if (e.statusCode === 404) return next()
       next(e)
     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.1.2",
+  "version": "2.3.0",
   "description": "Real-time image processing for your express application",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Switch to an API closer to Sharp's parameters.

- Pathnames like `/resize/480` are nonintuitive and defeat a lot of cache mechanisms.
- This approach is closer to other image optimizing APIs, allowing some potential fall-through in general purpose apps.